### PR TITLE
Part 2 - Verify Ethereum message signature

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -60,5 +60,7 @@ dependencies {
     implementation(name:'HtcWalletSDK-Htc_partner1-release', ext:'aar')
     implementation 'com.github.komputing.kethereum:model:0.82.4'
     implementation 'com.github.komputing.kethereum:crypto:0.82.4'
+    implementation 'com.github.komputing.kethereum:crypto_api:0.82.4'
     implementation 'com.github.komputing.kethereum:crypto_impl_spongycastle:0.82.4'
+    implementation 'com.github.komputing.kethereum:extensions_kotlin:0.82.4'
 }

--- a/app/src/main/java/com/htc/zion/demoapp/FirstFragment.kt
+++ b/app/src/main/java/com/htc/zion/demoapp/FirstFragment.kt
@@ -12,6 +12,7 @@ import androidx.fragment.app.Fragment
 import com.google.android.material.snackbar.Snackbar
 import com.google.gson.Gson
 import com.htc.htcwalletsdk.Native.Type.ByteArrayHolder
+import com.htc.htcwalletsdk.Utils.GenericUtils
 import com.htc.zion.demoapp.Utils.Companion.LOG_TAG
 import com.htc.zion.demoapp.Utils.Companion.convertToHex
 import com.htc.zion.demoapp.Utils.Companion.sha256
@@ -100,8 +101,9 @@ class FirstFragment : Fragment() {
                         bitmap.convertToHex()
                     }?.let { bitmapHex ->
                         bitmapHex.sha256()
-                    }?.let { bitmapHash ->
-                        val photoData = EthereumJsonTemplate(Message(bitmapHash))
+                    }?.let { msg ->
+                        val msgHex = GenericUtils.byteArrayToHex(msg.toByteArray())
+                        val photoData = EthereumJsonTemplate(Message(msgHex))
                         Log.i(LOG_TAG, "EthereumJson=$photoData")
                         val sig = ByteArrayHolder()
                         val uniqueId = Utils.getZkmaSdkUniqueId(this.requireContext())
@@ -117,7 +119,7 @@ class FirstFragment : Fragment() {
                         )
                         val verified = ZkmaSdkHelper.verifyEthMsgSignature(
                             uniqueId,
-                            bitmapHash,
+                            msg,
                             sig.byteArray
                         )
                         Log.i(


### PR DESCRIPTION
1. Convert message to be signed in HEX format
2. Convert message to be verified in EIP-191 format
3. Compare public keys in compressed format